### PR TITLE
Simpler interface

### DIFF
--- a/config.go
+++ b/config.go
@@ -2,7 +2,7 @@ package deluge
 
 import (
 	"encoding/json"
-	"time"
+	"net/http"
 )
 
 // Deluge WebUI methods.
@@ -19,23 +19,13 @@ const (
 
 // Config is the data needed to poll Deluge.
 type Config struct {
-	VerifySSL bool                                 `json:"verify_ssl" toml:"verify_ssl" xml:"verify_ssl" yaml:"verify_ssl"`
-	Timeout   Duration                             `json:"timeout" toml:"timeout" xml:"timeout" yaml:"timeout"`
-	URL       string                               `json:"url" toml:"url" xml:"url" yaml:"url"`
-	Password  string                               `json:"password" toml:"password" xml:"password" yaml:"password"`
-	HTTPPass  string                               `json:"http_pass" toml:"http_pass" xml:"http_pass" yaml:"http_pass"`
-	HTTPUser  string                               `json:"http_user" toml:"http_user" xml:"http_user" yaml:"http_user"`
-	Version   string                               `json:"version" toml:"version" xml:"version" yaml:"version"`
-	DebugLog  func(msg string, fmt ...interface{}) `json:"-" toml:"-" xml:"-" yaml:"-"`
-}
-
-// Duration is used to UnmarshalTOML into a time.Duration value.
-type Duration struct{ time.Duration }
-
-// UnmarshalText parses a duration type from a config file.
-func (d *Duration) UnmarshalText(data []byte) (err error) {
-	d.Duration, err = time.ParseDuration(string(data))
-	return
+	URL      string                               `json:"url" toml:"url" xml:"url" yaml:"url"`
+	Password string                               `json:"password" toml:"password" xml:"password" yaml:"password"`
+	HTTPPass string                               `json:"http_pass" toml:"http_pass" xml:"http_pass" yaml:"http_pass"`
+	HTTPUser string                               `json:"http_user" toml:"http_user" xml:"http_user" yaml:"http_user"`
+	Version  string                               `json:"version" toml:"version" xml:"version" yaml:"version"`
+	DebugLog func(msg string, fmt ...interface{}) `json:"-" toml:"-" xml:"-" yaml:"-"`
+	Client   *http.Client                         `json:"-" toml:"-" xml:"-" yaml:"-"`
 }
 
 // Response from Deluge

--- a/deluge.go
+++ b/deluge.go
@@ -3,7 +3,6 @@ package deluge
 import (
 	"bytes"
 	"context"
-	"crypto/tls"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -13,10 +12,8 @@ import (
 	"net/http/cookiejar"
 	"strconv"
 	"strings"
-	"time"
 
 	"golang.org/x/net/publicsuffix"
-	"golift.io/datacounter"
 )
 
 // Custom errors.
@@ -26,122 +23,118 @@ var (
 	ErrAuthFailed     = fmt.Errorf("authentication failed")
 )
 
-type Client struct {
-	*http.Client
-	cookie bool
-}
-
 // Deluge is what you get for providing a password.
 type Deluge struct {
-	*Client
-	*Config
+	password string
+	url      string
 	auth     string
 	id       int
+	client   *http.Client
+	cookie   bool
 	Version  string             // Currently unused, for display purposes only.
 	Backends map[string]Backend // Currently unused, for display purposes only.
-	DebugLog func(msg string, fmt ...interface{})
+	debug    func(msg string, fmt ...interface{})
 }
 
 // NewNoAuth returns a Deluge object without authenticating or trying to connect.
-func NewNoAuth(config *Config) (int64, *Deluge, error) {
+func NewNoAuth(config *Config) (*Deluge, error) {
 	return newConfig(config, false)
 }
 
 // New creates a http.Client with authenticated cookies.
 // Used to make additional, authenticated requests to the APIs.
-func New(config *Config) (int64, *Deluge, error) {
+func New(config *Config) (*Deluge, error) {
 	return newConfig(config, true)
 }
 
-func newConfig(config *Config, login bool) (int64, *Deluge, error) {
-	var bytes int64
-
+func newConfig(config *Config, login bool) (*Deluge, error) {
 	// The cookie jar is used to auth Deluge.
 	jar, err := cookiejar.New(&cookiejar.Options{PublicSuffixList: publicsuffix.List})
 	if err != nil {
-		return bytes, nil, fmt.Errorf("cookiejar.New(publicsuffix): %w", err)
+		return nil, fmt.Errorf("cookiejar.New(publicsuffix): %w", err)
 	}
 
 	config.URL = strings.TrimSuffix(strings.TrimSuffix(config.URL, "/json"), "/") + "/json"
 
 	// This app allows http auth, in addition to deluge web password.
-	if both := config.HTTPUser + ":" + config.HTTPPass; both != ":" {
-		config.HTTPUser = "Basic " + base64.StdEncoding.EncodeToString([]byte(both))
+	auth := config.HTTPUser + ":" + config.HTTPPass
+	if auth != ":" {
+		auth = "Basic " + base64.StdEncoding.EncodeToString([]byte(auth))
 	} else {
-		config.HTTPUser = ""
+		auth = ""
 	}
 
+	httpClient := config.Client
+	if httpClient == nil {
+		httpClient = &http.Client{}
+	}
+
+	httpClient.Jar = jar
+
 	deluge := &Deluge{
-		Config:   config,
-		auth:     config.HTTPUser,
+		auth:     auth,
 		Backends: make(map[string]Backend),
-		DebugLog: config.DebugLog,
-		Client: &Client{
-			Client: &http.Client{
-				Transport: &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: config.VerifySSL}}, //nolint:gosec
-				Jar:       jar,
-				Timeout:   config.Timeout.Round(time.Millisecond),
-			},
-		},
+		password: config.Password,
+		url:      config.URL,
+		client:   httpClient,
+		debug:    config.DebugLog,
 	}
 
 	if !login {
-		return bytes, deluge, nil
+		return deluge, nil
 	}
 
-	size, err := deluge.Login()
-	bytes += size
-
-	if err != nil {
-		return bytes, deluge, err
+	if err := deluge.Login(); err != nil {
+		return deluge, err
 	}
 
 	if deluge.Version = config.Version; deluge.Version == "" {
-		size, err = deluge.setVersion()
-		bytes += size
+		err = deluge.setVersion()
 
 		if err != nil {
-			return bytes, deluge, err
+			return deluge, err
 		}
 	}
 
-	return bytes, deluge, nil
+	return deluge, nil
 }
 
 // Login sets the cookie jar with authentication information.
-func (d *Deluge) Login() (int64, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), d.Timeout.Duration)
-	defer cancel()
+func (d *Deluge) Login() error {
+	return d.LoginContext(context.Background())
+}
 
+// LoginContext sets the cookie jar with authentication information.
+func (d *Deluge) LoginContext(ctx context.Context) error {
 	// This []string{config.Password} line is how you send auth creds. It's weird.
-	req, err := d.DelReq(ctx, AuthLogin, []string{d.Password})
+	req, err := d.DelReq(ctx, AuthLogin, []string{d.password})
 	if err != nil {
-		return 0, fmt.Errorf("DelReq(AuthLogin, json): %w", err)
+		return fmt.Errorf("DelReq(AuthLogin, json): %w", err)
 	}
 
-	resp, err := d.Do(req)
+	resp, err := d.client.Do(req)
 	if err != nil {
-		return 0, fmt.Errorf("d.Do(req): %w", err)
+		return fmt.Errorf("d.Do(req): %w", err)
 	}
 	defer resp.Body.Close()
 
-	size, _ := io.Copy(ioutil.Discard, resp.Body) // must read body to avoid memory leak.
+	_, _ = io.Copy(ioutil.Discard, resp.Body) // must read body to avoid memory leak.
 
 	if resp.StatusCode != http.StatusOK {
-		return size, fmt.Errorf("%w: %v[%v] (status: %v/%v)",
+		return fmt.Errorf("%w: %v[%v] (status: %v/%v)",
 			ErrAuthFailed, req.URL.String(), AuthLogin, resp.StatusCode, resp.Status)
 	}
 
-	d.Client.cookie = true
+	d.cookie = true
 
-	return size, nil
+	return nil
 }
 
 // setVersion digs into the first server in the web UI to find the version.
-func (d *Deluge) setVersion() (int64, error) {
-	bytes, response, err := d.Get(GeHosts, []string{})
+func (d *Deluge) setVersion() error {
+	response, err := d.Get(GeHosts, []string{})
 	if err != nil {
-		return bytes, err
+		return err
 	}
 
 	// This method returns a "mixed list" which requires an interface.
@@ -149,7 +142,7 @@ func (d *Deluge) setVersion() (int64, error) {
 	servers := make([][]interface{}, 0)
 	if err := json.Unmarshal(response.Result, &servers); err != nil {
 		d.logPayload(response.Result)
-		return bytes, fmt.Errorf("json.Unmarshal(rawResult1): %w", err)
+		return fmt.Errorf("json.Unmarshal(rawResult1): %w", err)
 	}
 
 	serverID := ""
@@ -164,36 +157,32 @@ func (d *Deluge) setVersion() (int64, error) {
 		}
 	}
 
-	total := bytes
-
 	// Store the last server's version as "the version"
-	bytes, response, err = d.Get(HostStatus, []string{serverID})
+	response, err = d.Get(HostStatus, []string{serverID})
 	if err != nil {
-		return total + bytes, err
+		return err
 	}
-
-	total += bytes
 
 	server := make([]interface{}, 0)
 	if err = json.Unmarshal(response.Result, &server); err != nil {
 		d.logPayload(response.Result)
-		return total, fmt.Errorf("json.Unmarshal(rawResult2): %w", err)
+		return fmt.Errorf("json.Unmarshal(rawResult2): %w", err)
 	}
 
 	const payloadSegments = 3
 
 	if len(server) < payloadSegments {
 		d.logPayload(response.Result)
-		return total, ErrInvalidVersion
+		return ErrInvalidVersion
 	}
 
 	// Version comes last in the mixed list.
 	var ok bool
 	if d.Version, ok = server[len(server)-1].(string); !ok {
-		return total, ErrInvalidVersion
+		return ErrInvalidVersion
 	}
 
-	return total, nil
+	return nil
 }
 
 // DelReq is a small helper function that adds headers and marshals the json.
@@ -203,7 +192,7 @@ func (d Deluge) DelReq(ctx context.Context, method string, params interface{}) (
 	paramMap := map[string]interface{}{"method": method, "id": d.id, "params": params}
 	if data, errr := json.Marshal(paramMap); errr != nil {
 		return req, fmt.Errorf("json.Marshal(params): %w", err)
-	} else if req, err = http.NewRequestWithContext(ctx, "POST", d.URL, bytes.NewBuffer(data)); err == nil {
+	} else if req, err = http.NewRequestWithContext(ctx, "POST", d.url, bytes.NewBuffer(data)); err == nil {
 		if d.auth != "" {
 			// In case Deluge is also behind HTTP auth.
 			req.Header.Add("Authorization", d.auth)
@@ -217,85 +206,84 @@ func (d Deluge) DelReq(ctx context.Context, method string, params interface{}) (
 }
 
 // GetXfers gets all the Transfers from Deluge.
-func (d Deluge) GetXfers() (int64, map[string]*XferStatus, error) {
+func (d Deluge) GetXfers() (map[string]*XferStatus, error) {
 	xfers := make(map[string]*XferStatus)
 
-	bytes, response, err := d.Get(GetAllTorrents, []string{"", ""})
+	response, err := d.Get(GetAllTorrents, []string{"", ""})
 	if err != nil {
-		return bytes, xfers, fmt.Errorf("get(GetAllTorrents): %w", err)
+		return xfers, fmt.Errorf("get(GetAllTorrents): %w", err)
 	}
 
 	if err := json.Unmarshal(response.Result, &xfers); err != nil {
 		d.logPayload(response.Result)
-		return bytes, xfers, fmt.Errorf("json.Unmarshal(xfers): %w", err)
+		return xfers, fmt.Errorf("json.Unmarshal(xfers): %w", err)
 	}
 
-	return bytes, xfers, nil
+	return xfers, nil
 }
 
 // GetXfersCompat gets all the Transfers from Deluge 1.x or 2.x.
 // Depend on what you're actually trying to do, this is likely the best method to use.
 // This will return a combined struct hat has data for Deluge 1 and Deluge 2.
 // All of the data for either version will be made available with this method.
-func (d Deluge) GetXfersCompat() (int64, map[string]*XferStatusCompat, error) {
+func (d Deluge) GetXfersCompat() (map[string]*XferStatusCompat, error) {
 	xfers := make(map[string]*XferStatusCompat)
 
-	bytes, response, err := d.Get(GetAllTorrents, []string{"", ""})
+	response, err := d.Get(GetAllTorrents, []string{"", ""})
 	if err != nil {
-		return bytes, xfers, fmt.Errorf("get(GetAllTorrents): %w", err)
+		return xfers, fmt.Errorf("get(GetAllTorrents): %w", err)
 	}
 
 	if err := json.Unmarshal(response.Result, &xfers); err != nil {
 		d.logPayload(response.Result)
-		return bytes, xfers, fmt.Errorf("json.Unmarshal(xfers): %w", err)
+		return xfers, fmt.Errorf("json.Unmarshal(xfers): %w", err)
 	}
 
-	return bytes, xfers, nil
+	return xfers, nil
 }
 
 // Get a response from Deluge.
-func (d Deluge) Get(method string, params interface{}) (int64, *Response, error) {
+func (d *Deluge) Get(method string, params interface{}) (*Response, error) {
+	return d.GetContext(context.Background(), method, params)
+}
+
+func (d *Deluge) GetContext(ctx context.Context, method string, params interface{}) (*Response, error) {
 	var response Response
 
 	if !d.cookie {
-		if size, err := d.Login(); err != nil {
-			return size, &response, err
+		if err := d.Login(); err != nil {
+			return &response, err
 		}
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), d.Timeout.Duration)
-	defer cancel()
-
 	req, err := d.DelReq(ctx, method, params)
 	if err != nil {
-		return 0, &response, fmt.Errorf("d.DelReq: %w", err)
+		return &response, fmt.Errorf("d.DelReq: %w", err)
 	}
 
-	resp, err := d.Do(req)
+	resp, err := d.client.Do(req)
 	if err != nil {
-		return 0, &response, fmt.Errorf("d.Do: %w", err)
+		return &response, fmt.Errorf("d.Do: %w", err)
 	}
 	defer resp.Body.Close()
 
-	counter := datacounter.NewReaderCounter(resp.Body)
-
-	if err = json.NewDecoder(counter).Decode(&response); err != nil {
+	if err = json.NewDecoder(resp.Body).Decode(&response); err != nil {
 		d.logPayload(response.Result)
-		return int64(counter.Count()), &response, fmt.Errorf("json.Unmarshal(response): %w", err)
+		return &response, fmt.Errorf("json.Unmarshal(response): %w", err)
 	}
 
 	if response.Error.Code != 0 {
-		d.Client.cookie = false
-		return int64(counter.Count()), &response, fmt.Errorf("%w: %s", ErrDelugeError, response.Error.Message)
+		d.cookie = false
+		return &response, fmt.Errorf("%w: %s", ErrDelugeError, response.Error.Message)
 	}
 
-	return int64(counter.Count()), &response, nil
+	return &response, nil
 }
 
 // Log logs a debug message.
 func (d *Deluge) Log(msg string, fmt ...interface{}) {
-	if d.DebugLog != nil {
-		d.DebugLog(msg, fmt...)
+	if d.debug != nil {
+		d.debug(msg, fmt...)
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,4 @@ module golift.io/deluge
 
 go 1.17
 
-require (
-  golang.org/x/net v0.0.0-20211118161319-6a13c67c3ce4
-  golift.io/datacounter v1.0.3
-)
+require golang.org/x/net v0.0.0-20211118161319-6a13c67c3ce4

--- a/go.sum
+++ b/go.sum
@@ -5,5 +5,3 @@ golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
-golift.io/datacounter v1.0.3 h1:qDIkyEMimhgWIbPoIZ3mjOP9hiwtO6yBcuyNYjea3l0=
-golift.io/datacounter v1.0.3/go.mod h1:79Yf1ucynYvZzVS/hpfrAFt6y/w82FMlOJgh+MBaZvs=


### PR DESCRIPTION
This replaces the timeout and verify_ssl inputs with an http.Client. Removes the response body size from all methods and provides a context input.