### PR TITLE
Simplify

### DIFF
--- a/config.go
+++ b/config.go
@@ -19,13 +19,12 @@ const (
 
 // Config is the data needed to poll Deluge.
 type Config struct {
-	URL      string                               `json:"url" toml:"url" xml:"url" yaml:"url"`
-	Password string                               `json:"password" toml:"password" xml:"password" yaml:"password"`
-	HTTPPass string                               `json:"http_pass" toml:"http_pass" xml:"http_pass" yaml:"http_pass"`
-	HTTPUser string                               `json:"http_user" toml:"http_user" xml:"http_user" yaml:"http_user"`
-	Version  string                               `json:"version" toml:"version" xml:"version" yaml:"version"`
-	DebugLog func(msg string, fmt ...interface{}) `json:"-" toml:"-" xml:"-" yaml:"-"`
-	Client   *http.Client                         `json:"-" toml:"-" xml:"-" yaml:"-"`
+	URL      string       `json:"url" toml:"url" xml:"url" yaml:"url"`
+	Password string       `json:"password" toml:"password" xml:"password" yaml:"password"`
+	HTTPPass string       `json:"http_pass" toml:"http_pass" xml:"http_pass" yaml:"http_pass"`
+	HTTPUser string       `json:"http_user" toml:"http_user" xml:"http_user" yaml:"http_user"`
+	Version  string       `json:"version" toml:"version" xml:"version" yaml:"version"`
+	Client   *http.Client `json:"-" toml:"-" xml:"-" yaml:"-"`
 }
 
 // Response from Deluge

--- a/deluge.go
+++ b/deluge.go
@@ -24,6 +24,7 @@ var (
 )
 
 // Deluge is what you get for providing a password.
+// Version and Backends are only filled if you call New().
 type Deluge struct {
 	password string
 	url      string
@@ -33,7 +34,6 @@ type Deluge struct {
 	cookie   bool
 	Version  string             // Currently unused, for display purposes only.
 	Backends map[string]Backend // Currently unused, for display purposes only.
-	debug    func(msg string, fmt ...interface{})
 }
 
 // NewNoAuth returns a Deluge object without authenticating or trying to connect.
@@ -54,7 +54,7 @@ func newConfig(ctx context.Context, config *Config, login bool) (*Deluge, error)
 		return nil, fmt.Errorf("cookiejar.New(publicsuffix): %w", err)
 	}
 
-	config.URL = strings.TrimSuffix(strings.TrimSuffix(config.URL, "/json"), "/") + "/json"
+	delugeURL := strings.TrimSuffix(strings.TrimSuffix(config.URL, "/json"), "/") + "/json"
 
 	// This app allows http auth, in addition to deluge web password.
 	auth := config.HTTPUser + ":" + config.HTTPPass
@@ -75,9 +75,8 @@ func newConfig(ctx context.Context, config *Config, login bool) (*Deluge, error)
 		auth:     auth,
 		Backends: make(map[string]Backend),
 		password: config.Password,
-		url:      config.URL,
+		url:      delugeURL,
 		client:   httpClient,
-		debug:    config.DebugLog,
 	}
 
 	if !login {
@@ -89,9 +88,7 @@ func newConfig(ctx context.Context, config *Config, login bool) (*Deluge, error)
 	}
 
 	if deluge.Version = config.Version; deluge.Version == "" {
-		err = deluge.setVersion(ctx)
-
-		if err != nil {
+		if err = deluge.setVersion(ctx); err != nil {
 			return deluge, err
 		}
 	}
@@ -106,7 +103,7 @@ func (d *Deluge) Login() error {
 
 // LoginContext sets the cookie jar with authentication information.
 func (d *Deluge) LoginContext(ctx context.Context) error {
-	// This []string{config.Password} line is how you send auth creds. It's weird.
+	// This line is how you send auth creds.
 	req, err := d.DelReq(ctx, AuthLogin, []string{d.password})
 	if err != nil {
 		return fmt.Errorf("DelReq(AuthLogin, json): %w", err)
@@ -141,7 +138,6 @@ func (d *Deluge) setVersion(ctx context.Context) error {
 	// Deluge devs apparently hate Go. :(
 	servers := make([][]interface{}, 0)
 	if err := json.Unmarshal(response.Result, &servers); err != nil {
-		d.logPayload(response.Result)
 		return fmt.Errorf("json.Unmarshal(rawResult1): %w", err)
 	}
 
@@ -165,14 +161,12 @@ func (d *Deluge) setVersion(ctx context.Context) error {
 
 	server := make([]interface{}, 0)
 	if err = json.Unmarshal(response.Result, &server); err != nil {
-		d.logPayload(response.Result)
 		return fmt.Errorf("json.Unmarshal(rawResult2): %w", err)
 	}
 
 	const payloadSegments = 3
 
 	if len(server) < payloadSegments {
-		d.logPayload(response.Result)
 		return ErrInvalidVersion
 	}
 
@@ -215,12 +209,11 @@ func (d *Deluge) GetXfersContext(ctx context.Context) (map[string]*XferStatus, e
 
 	response, err := d.Get(ctx, GetAllTorrents, []string{"", ""})
 	if err != nil {
-		return xfers, fmt.Errorf("get(GetAllTorrents): %w", err)
+		return nil, fmt.Errorf("get(GetAllTorrents): %w", err)
 	}
 
 	if err := json.Unmarshal(response.Result, &xfers); err != nil {
-		d.logPayload(response.Result)
-		return xfers, fmt.Errorf("json.Unmarshal(xfers): %w", err)
+		return nil, fmt.Errorf("json.Unmarshal(xfers): %w", err)
 	}
 
 	return xfers, nil
@@ -239,12 +232,11 @@ func (d *Deluge) GetXfersCompatContext(ctx context.Context) (map[string]*XferSta
 
 	response, err := d.Get(ctx, GetAllTorrents, []string{"", ""})
 	if err != nil {
-		return xfers, fmt.Errorf("get(GetAllTorrents): %w", err)
+		return nil, fmt.Errorf("get(GetAllTorrents): %w", err)
 	}
 
 	if err := json.Unmarshal(response.Result, &xfers); err != nil {
-		d.logPayload(response.Result)
-		return xfers, fmt.Errorf("json.Unmarshal(xfers): %w", err)
+		return nil, fmt.Errorf("json.Unmarshal(xfers): %w", err)
 	}
 
 	return xfers, nil
@@ -252,28 +244,26 @@ func (d *Deluge) GetXfersCompatContext(ctx context.Context) (map[string]*XferSta
 
 // Get a response from Deluge.
 func (d *Deluge) Get(ctx context.Context, method string, params interface{}) (*Response, error) {
-	var response Response
-
 	if !d.cookie {
-		if err := d.Login(); err != nil {
-			return &response, err
+		if err := d.LoginContext(ctx); err != nil {
+			return nil, err
 		}
 	}
 
 	req, err := d.DelReq(ctx, method, params)
 	if err != nil {
-		return &response, fmt.Errorf("d.DelReq: %w", err)
+		return nil, fmt.Errorf("d.DelReq: %w", err)
 	}
 
 	resp, err := d.client.Do(req)
 	if err != nil {
-		return &response, fmt.Errorf("d.Do: %w", err)
+		return nil, fmt.Errorf("d.Do: %w", err)
 	}
 	defer resp.Body.Close()
 
+	var response Response
 	if err = json.NewDecoder(resp.Body).Decode(&response); err != nil {
-		d.logPayload(response.Result)
-		return &response, fmt.Errorf("json.Unmarshal(response): %w", err)
+		return nil, fmt.Errorf("json.Unmarshal(response): %w", err)
 	}
 
 	if response.Error.Code != 0 {
@@ -282,22 +272,4 @@ func (d *Deluge) Get(ctx context.Context, method string, params interface{}) (*R
 	}
 
 	return &response, nil
-}
-
-// Log logs a debug message.
-func (d *Deluge) Log(msg string, fmt ...interface{}) {
-	if d.debug != nil {
-		d.debug(msg, fmt...)
-	}
-}
-
-// logPayload writes a json payload to output. Used for debugging API data.
-func (d *Deluge) logPayload(result json.RawMessage) {
-	out, err := result.MarshalJSON()
-
-	d.Log("Failed Payload:\n%s\n", string(out))
-
-	if err != nil {
-		d.Log("Payload Marshal Error: %v", err)
-	}
 }


### PR DESCRIPTION
Simplifies a lot of cruft. Removes the logger. Re-logs-in if a request is unauthenticated. No longer overwrites the passed-in URL.